### PR TITLE
Vuln 1458

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,9 +2690,9 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"node_modules/json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://npm.tradeshift.net/repository/npm-all/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -2723,17 +2723,17 @@
 			}
 		},
 		"node_modules/jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://npm.tradeshift.net/repository/npm-all/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"engines": [
-				"node >=0.6.0"
-			],
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"dependencies": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
+			},
+			"engines": {
+				"node": ">=0.6.0"
 			}
 		},
 		"node_modules/jwt-simple": {
@@ -7068,9 +7068,9 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://npm.tradeshift.net/repository/npm-all/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -7098,13 +7098,13 @@
 			}
 		},
 		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://npm.tradeshift.net/repository/npm-all/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
+				"json-schema": "0.4.0",
 				"verror": "1.10.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
 				"ngrok": "3.2.7",
 				"object-hash": "2.0.3",
 				"passport-oauth2": "1.6.1",
-				"request": "2.88.2",
 				"request-promise-native": "1.0.8",
 				"uuid": "8.3.2"
 			},

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"ngrok": "3.2.7",
 		"object-hash": "2.0.3",
 		"passport-oauth2": "1.6.1",
-		"request": "2.88.2",
 		"request-promise-native": "1.0.8",
 		"uuid": "8.3.2"
 	},

--- a/package.json
+++ b/package.json
@@ -41,5 +41,10 @@
 		"eslint-config-airbnb-base": "14.1.0",
 		"eslint-plugin-import": "2.25.4",
 		"nodemon": "2.0.2"
+	},
+	"overrides": {
+		"ngrok": {
+			"jsprim": "1.4.2"
+		}
 	}
 }


### PR DESCRIPTION
Removes unused direct dependency `request`.
Overrides `ngrok` subdependency `jsprim` to resolve `json-schema` vulnerability.