### PR TITLE
Fixing dependencies for eslint-config-airbnb-base@14.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"uuid": "8.3.2"
 	},
 	"devDependencies": {
-		"eslint": "6.5.0",
+		"eslint": "6.8.0",
 		"eslint-config-airbnb-base": "14.1.0",
 		"eslint-plugin-import": "2.25.4",
 		"nodemon": "2.0.2"


### PR DESCRIPTION
This solves the requirement for eslint-config-airbnb-base@14.1.0 from 6.5.0, to 6.8.0. Since is a minor version, should be not any problems of using this.

ref: https://github.com/Tradeshift/bucko/actions/runs/3822053320/jobs/6501809769